### PR TITLE
java: Fix "is build up to date" logic.

### DIFF
--- a/java/build
+++ b/java/build
@@ -3,5 +3,6 @@ set -euo pipefail
 
 [[ ! -e out ]] || rm -r out
 mkdir -p out
-touch out/stamp
+touch out/stamp-pre
 javac -d out src/*.java
+touch out/stamp-post

--- a/java/ensure-built
+++ b/java/ensure-built
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 rebuild=true
-if [[ -f out/stamp ]]; then
-    if [[ "$(find build src -newer "out/stamp" | head -c 1)" == "" ]]; then
+if [[ -f out/stamp-post ]]; then
+    # Make sure all input files haven't changed since the last build *started*.
+    if [[ "$(find build src -newer "out/stamp-pre" | head -c 1)" == "" ]]; then
         rebuild=false
     fi
 fi


### PR DESCRIPTION
We were checking for the presence of "out/stamp", which is created
before "javac".  So if "javac" failed, we'd still think the build was up
to date.  So dumb.